### PR TITLE
start.sh: fix HF_TOKEN detection and harden .env parsing

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -111,7 +111,12 @@ set -euo pipefail
 # Shell env vars already set win; .env fills the gaps; defaults apply last.
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 if [[ -f "${SCRIPT_DIR}/.env" ]]; then
-  while IFS='=' read -r key value; do
+  # `|| [[ -n "${key}" ]]` so a final line without a trailing newline is not dropped.
+  while IFS='=' read -r key value || [[ -n "${key}" ]]; do
+    # Tolerate CRLF files and surrounding whitespace, and skip indented comments —
+    # otherwise `${!key}` below would be an indirect expansion on an invalid name.
+    key="${key%$'\r'}"; value="${value%$'\r'}"
+    key="${key#"${key%%[![:space:]]*}"}"; key="${key%"${key##*[![:space:]]}"}"
     [[ -z "${key}" || "${key}" == \#* ]] && continue
     if [[ -z "${!key:-}" ]]; then
       export "${key}=${value}"
@@ -196,7 +201,9 @@ mkdir -p "${HF_HOME}" "${TRITON_CACHE_DIR}"
 # Pick up HF_TOKEN from ~/.bashrc (defined without `export` there) so the
 # container gets authenticated Hub access (higher rate limits, faster downloads).
 if [[ -z "${HF_TOKEN:-}" && -f "${HOME}/.bashrc" ]]; then
-  HF_TOKEN="$(sed -n 's/^HF_TOKEN=["'"'"']\?\([A-Za-z0-9_-]\+\).*/\1/p' "${HOME}/.bashrc" | head -1)"
+  # Accept `export HF_TOKEN=…` (the idiomatic form: a bare assignment in .bashrc is
+  # not exported to child processes) as well as a plain `HF_TOKEN=…`.
+  HF_TOKEN="$(sed -n 's/^[[:space:]]*\(export[[:space:]]\+\)\?HF_TOKEN=["'"'"']\?\([A-Za-z0-9_-]\+\).*/\2/p' "${HOME}/.bashrc" | head -1)"
 fi
 export HF_TOKEN
 


### PR DESCRIPTION
Brought this recipe up on a DGX Spark today. It works as written — these are four issues in
`start.sh`'s config preamble that I hit or found while doing it. All reproduced against
`5d2df79`, then re-verified with the patch.

## 1. `export HF_TOKEN=…` in `~/.bashrc` is never picked up

The README says the token should be *"defined in `~/.bashrc` (picked up automatically; higher
rate limits)"*. The extraction only matches a **bare** assignment at line start:

```bash
sed -n 's/^HF_TOKEN=["'"'"']\?\([A-Za-z0-9_-]\+\).*/\1/p' "${HOME}/.bashrc"
```

`^HF_TOKEN=` doesn't match `export HF_TOKEN=…` — which is the idiomatic form, and the only one
that actually exports to child processes. So the natural way to follow the README is the one
that silently fails:

```console
$ grep -n HF_TOKEN ~/.bashrc
118:export HF_TOKEN=hf_xxxxxxxx

$ ./start.sh
$ docker inspect qwen3.8-27b-sglang --format '{{range .Config.Env}}{{println .}}{{end}}' | grep ^HF_TOKEN=
HF_TOKEN=          # empty
```

The server still starts and public checkpoints still download, just unauthenticated — so the
rate-limit benefit is lost, and a gated repo would fail deep in the pull instead of saying
"no token".

## 2. `.env`'s last line is dropped without a trailing newline

```console
$ printf 'QUANT=nvfp4\nCONTEXT_LENGTH=262144' > .env    # no trailing \n
QUANT=nvfp4 CONTEXT_LENGTH=<unset>
```

`while IFS='=' read -r key value` stops before an unterminated final line, so that setting is
silently ignored and the server starts on a default the operator believes they overrode.

## 3. An indented comment in `.env` aborts the launch

```console
$ printf 'QUANT=nvfp4\n   # indented comment\nCONTEXT_LENGTH=262144\n' > .env
./start.sh: line 7:    # indented comment: invalid variable name
```

Only `#` at column 0 is skipped. An indented comment becomes a key containing spaces, and
`${!key:-}` then does indirect expansion on an invalid identifier — fatal under
`set -euo pipefail`. `.env.sample` is heavily commented, so indenting one while editing is an
easy way to hit this, and the error points at bash internals rather than at the file.

## 4. CRLF line endings produce misleading errors

```console
$ printf 'QUANT=nvfp4\r\nCONTEXT_LENGTH=262144\r\n' > .env
-> Unknown QUANT 'nvfp4<CR>' (use bf16|fp8|nvfp4)
((: 262144<CR>: syntax error: invalid arithmetic operator (error token is "")
```

The `QUANT` message is the awkward one — the value looks correct in the error text unless you
already suspect a carriage return.

## The fix

- accept an optional `export ` prefix and leading whitespace when reading `HF_TOKEN`
- guard the read loop with `|| [[ -n "${key}" ]]`
- strip `\r` and surrounding whitespace from key/value before the comment check

9 insertions, 2 deletions, no behaviour change for a well-formed `.env`.

## Verified on

DGX Spark (GB10, aarch64), Ubuntu 24.04.4, driver 580.173.02, image
`lmsysorg/sglang:qwen38-27b`, `QUANT=nvfp4`, 262K context.

| case | before | after |
|---|---|---|
| `export HF_TOKEN=…` in `.bashrc` | container gets `HF_TOKEN=` (empty) | token populated — confirmed via `docker inspect` on a real restart |
| `.env` with no trailing newline | last setting dropped | parsed |
| indented comment in `.env` | `invalid variable name`, launch aborts | skipped |
| CRLF `.env` | `Unknown QUANT 'nvfp4<CR>'` | parsed |
| normal `.env` | works | unchanged |

Thanks for putting this recipe out — it came up cleanly otherwise, and the SGLang cookbook
notes in the README saved a lot of time.